### PR TITLE
Renderizando dados de endereco do modelo no fragmento

### DIFF
--- a/app/src/main/resources/templates/fragments/endereco.html
+++ b/app/src/main/resources/templates/fragments/endereco.html
@@ -1,29 +1,65 @@
-<div th:fragment="endereco">
+<fieldset th:fragment="endereco (disabled)" th:disabled="${disabled}">
   <div class="mb-3">
     <label for="cep" class="form-label">Cep</label>
-    <input type="text" class="form-control" id="cep" name="cep">
+    <input
+      type="text"
+      class="form-control"
+      id="cep"
+      name="cep"
+      th:field="*{endereco.cep}"
+    />
   </div>
   <div class="mb-3">
     <label for="logradouro" class="form-label">Logradouro</label>
-    <input type="text" class="form-control" id="logradouro" name="logradouro">
+    <input
+      type="text"
+      class="form-control"
+      id="logradouro"
+      name="logradouro"
+      th:field="*{endereco.logradouro}"
+    />
+  </div>
+  <div class="mb-3">
+    <label for="bairro" class="form-label">Bairro</label>
+    <input
+      type="text"
+      class="form-control"
+      id="bairro"
+      name="bairro"
+      th:field="*{endereco.bairro}"
+    />
   </div>
   <div class="mb-3">
     <label for="numero" class="form-label">Numero</label>
-    <input type="text" class="form-control" id="endereco-numero" name="numero">
-  </div>
-  <div class="mb-3">
-    <label for="complemento" class="form-label">Complemento</label>
-    <input type="text" class="form-control" id="complemento" name="complemento">
+    <input
+      type="text"
+      class="form-control"
+      id="numero"
+      name="numero"
+      th:field="*{endereco.numero}"
+    />
   </div>
   <div class="mb-3">
     <label for="cidade" class="form-label">Cidade</label>
-    <input type="text" class="form-control" id="cidade" name="cidade">
+    <input
+      type="text"
+      class="form-control"
+      id="cidade"
+      name="cidade"
+      th:field="*{endereco.cidade}"
+    />
   </div>
   <div class="mb-3">
     <label for="estado" class="form-label">Estado</label>
-    <input type="text" class="form-control" id="estado" name="estado">
+    <input
+      type="text"
+      class="form-control"
+      id="estado"
+      name="estado"
+      th:field="*{endereco.estado}"
+    />
   </div>
 
   <script src="/js/shared/endereco.js"></script>
   <script src="/libs/jquery/jquery-3.6.4.min.js"></script>
-</div>
+</fieldset>


### PR DESCRIPTION
## Introdução
A partir deste pull request o fragmento "endereco" passa a renderizar os dados de endereco do model, sendo assim, o fragmento poderá ser utilizado tanto para cadastro como para edição e visualização.

## Como usar
1. O fragmento deve ser utilizado dentro de um formulário, por exemplo:
```html
<form>
  ...
  <<fragmento>>
</form>
```
 
2. O `th:object` deste formulário deve possuir a propriedade "endereco" do tipo `EnderecoDto` (dto presente em endereco > dtos > EnderecoDto).

- ### Páginas de cadastro e edição:
```html
<div th:replace="fragments/endereco :: endereco(_)"></div>
```
Observe ` endereco(_)`. Aqui é usado o operador [no-operation token](https://www.thymeleaf.org/doc/tutorials/3.0/usingthymeleaf.html#using-the-no-operation-token) do thymleaf. Isto é necessário por que o fragment recebe o parâmetro `disabled` (booleano), que é usado para informar quando o fragment deve desabilitar os campos de endereço (no caso de visualização por exemplo). Neste caso, usamos o operador para descartar a necessidade de passar um valor, pois no caso de cadastro e edição os campos estarão habilitados.

- ### Páginas de visualização
```html
<div th:replace="fragments/endereco :: endereco(disabled=true)"></div>
```

Observe `endereco(disabled=true)`. O parâmetro disabled é utilizado para informar ao fragmento que os campos devem ser desabilitados.

