### PR TITLE
No e All constructor notation no EnderecoDto

### DIFF
--- a/app/src/main/java/hkeller/escolacaesguia/endereco/dtos/EnderecoDto.java
+++ b/app/src/main/java/hkeller/escolacaesguia/endereco/dtos/EnderecoDto.java
@@ -1,10 +1,14 @@
 package hkeller.escolacaesguia.endereco.dtos;
 
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
 @Data
 @Builder
+@NoArgsConstructor
+@AllArgsConstructor
 public class EnderecoDto {
   private int cep;
   private String logradouro;


### PR DESCRIPTION
Adicionado as notations NoArgsConstructor e AllArgsConstructor para no endereco dto. Sem isto gerava erro quando era instanciado uma classe que continha a propriedade EnderecoDto sem fazer um new no EnderecoDto. Desta forma, o EnderecoDto será construído automaticamente como vazio se não for instanciado.